### PR TITLE
removed textinput box

### DIFF
--- a/screens/home.js
+++ b/screens/home.js
@@ -183,7 +183,13 @@ export default class Home extends Component {
 
      }
     renderQuickReplySend = () => <Text>{' custom send =>'}</Text>
-
+    renderInputToolbar(props){
+    if(this.state.toolbar){
+    return(
+    <InputToolbar {...props} />
+    );
+    }
+    }
     render() {
       return (
         <View style={{ flex: 1, backgroundColor: '#fff' }}>
@@ -194,7 +200,7 @@ export default class Home extends Component {
             quickReplyStyle={{ borderRadius: 2 }}
             onQuickReply={this.onQuickReply}
             renderQuickReplySend={this.renderQuickReplySend}
-
+            renderInputToolbar={(props) => this.renderInputToolbar(props)}
           />
         </View>
         );


### PR DESCRIPTION
User does not see the textbox to enter responses and can only select quick replies.

#### Link to the issue: 
https://github.com/de-souza-capstone-2020/Mars/issues/50
#### Description of Pull Request:
Disabled text input on chatbot interface

#### Test Plan:

- [ ] Step_One: Pull branch
- [ ] Step_Two: Navigate to chatbot interface
- [ ] Step_Three: select quick reply response, no keyboard options should be available.

