### PR TITLE
Feature/states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,11 @@ RNTester/build
 local.properties
 *.iml
 /android/
+/android/.gradle/
+android/
 android/app/build
 android/build
+android/.gradle/
 build/
 
 # Files for the ART/Dalvik VM

--- a/screens/chat-screen/home.js
+++ b/screens/chat-screen/home.js
@@ -3,8 +3,9 @@ import { StyleSheet, Text, View, Image, Button, AsyncStorage } from "react-nativ
 import { GiftedChat } from "react-native-gifted-chat";
 import Moment from "moment";
 import SleepDiary from "../sleepDiary";
-import sleep_diary_messages from "../data/messages";
+import { generic_messages, sleep_diary_messages }  from "../data/messages";
 import { sleep_diary_response } from "../data/customActions";
+import SplashScreen from "../loading";
 
 const user = {
   _id: 1,
@@ -20,52 +21,70 @@ const otherUser = {
 const getID = () => Math.round(Math.random() * 1000000);
 
 export default class Home extends Component {
-
-  
   state = {
-    messages: sleep_diary_messages,
+    messages: generic_messages,
     typingText: null,
     isModalVisible: false,
     diary: '',
+    isLoading: true,
     appState: new Set() 
   };
   
-  componentDidMount() {
+  async componentDidMount() {
     
-    this.determineState();
-    console.log("in componentDidMount");
-    console.log(this.state.appState);
+    await this.isSleepDiaryEntered();
+    console.log('inside comp');
+    console.log(this.state.appState)
+
+    //determining message type
+    const { appState } = this.state;
+    if(appState.size > 0 ) {
+      if (appState.has(1)) {
+        this.setState({ messages: sleep_diary_messages });
+      }
+      this.setState({
+        isLoading: false,
+      });
+    }
   }
 
-  determineState = () => {
-    this.isSleepDiaryEntered();
-    //other functions
-  }
 
-
-
-  isSleepDiaryEntered = () => {
+  /** 
+   * determines if there is a sleep diary entry for today
+   * sets app state to 1 if there is no entry
+   * sets app state to 2, 3, 4 if there is
+   */
+  isSleepDiaryEntered = async() => {
     // var date = Moment(date).format("MM-DD-YYYY")
     var appState = this.state.appState;
     var date = "02-12-2020"; //for testing
     try {
       AsyncStorage.getAllKeys().then((keys) => {
-        // console.log(keys);
+        console.log(keys);
         if (keys.indexOf(date) != -1) {
           console.log('found')
-          appState.add(1);
+          appState.clear();
+          appState.add(2);
+          appState.add(3);
+          appState.add(4);
           this.setState({appState});
           console.log(this.state.appState)
         } else {
-          appState.delete(1);
+          appState.clear();
+          appState.add(1);
           this.setState({appState});
         }
-      });
-      console.log('inside func');
-      console.log(this.state.appState)
+      }); 
     } catch (e) {
       console.error(e);
     }
+
+    return new Promise((resolve) =>
+      setTimeout(
+        () => { resolve('result') },
+        2000
+      )
+    );
   }
 
   toggleModal = () => {
@@ -216,8 +235,10 @@ export default class Home extends Component {
   };
 
   render() {
-    const { messages, isModalVisible } = this.state;
-    
+    const { messages, isModalVisible, isLoading } = this.state;
+    if (isLoading) {
+      return <SplashScreen />;
+    }
     return (
       <View style={{ flex: 1, backgroundColor: "#fff" }}>
         <GiftedChat

--- a/screens/chat-screen/home.js
+++ b/screens/chat-screen/home.js
@@ -33,27 +33,35 @@ export default class Home extends Component {
   componentDidMount() {
     
     this.determineState();
+    console.log("in componentDidMount");
     console.log(this.state.appState);
   }
 
-  determineState(){
+  determineState = () => {
     this.isSleepDiaryEntered();
+    //other functions
   }
 
-  isSleepDiaryEntered = async () => {
+
+
+  isSleepDiaryEntered = () => {
     // var date = Moment(date).format("MM-DD-YYYY")
     var appState = this.state.appState;
-    var date = "02-10-2020";
+    var date = "02-12-2020"; //for testing
     try {
-      const keys = await AsyncStorage.getAllKeys().then(
-      )
-      if (keys.indexOf(date) != -1) {
-        appState.add(1);
-        this.setState({appState});
-      } else {
-        appState.delete(1);
-        this.setState({appState});
-      }
+      AsyncStorage.getAllKeys().then((keys) => {
+        // console.log(keys);
+        if (keys.indexOf(date) != -1) {
+          console.log('found')
+          appState.add(1);
+          this.setState({appState});
+          console.log(this.state.appState)
+        } else {
+          appState.delete(1);
+          this.setState({appState});
+        }
+      });
+      console.log('inside func');
       console.log(this.state.appState)
     } catch (e) {
       console.error(e);

--- a/screens/chat-screen/home.js
+++ b/screens/chat-screen/home.js
@@ -56,8 +56,8 @@ export default class Home extends Component {
    */
   isSleepDiaryEntered = async() => {
     // var date = Moment(date).format("MM-DD-YYYY")
-    var appState = this.state.appState;
-    var date = "02-12-2020"; //for testing
+    const appState = this.state.appState;
+    const date = "02-12-2020"; //for testing
     try {
       AsyncStorage.getAllKeys().then((keys) => {
         console.log(keys);

--- a/screens/chat-screen/home.js
+++ b/screens/chat-screen/home.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
-import { StyleSheet, Text, View, Image, Button, } from "react-native";
+import { StyleSheet, Text, View, Image, Button, AsyncStorage } from "react-native";
 import { GiftedChat } from "react-native-gifted-chat";
+import Moment from "moment";
 import SleepDiary from "../sleepDiary";
 import sleep_diary_messages from "../data/messages";
 import { sleep_diary_response } from "../data/customActions";
@@ -19,11 +20,45 @@ const otherUser = {
 const getID = () => Math.round(Math.random() * 1000000);
 
 export default class Home extends Component {
+
+  
   state = {
     messages: sleep_diary_messages,
     typingText: null,
-    isModalVisible: false
+    isModalVisible: false,
+    diary: '',
+    appState: new Set() 
   };
+  
+  componentDidMount() {
+    
+    this.determineState();
+    console.log(this.state.appState);
+  }
+
+  determineState(){
+    this.isSleepDiaryEntered();
+  }
+
+  isSleepDiaryEntered = async () => {
+    // var date = Moment(date).format("MM-DD-YYYY")
+    var appState = this.state.appState;
+    var date = "02-10-2020";
+    try {
+      const keys = await AsyncStorage.getAllKeys().then(
+      )
+      if (keys.indexOf(date) != -1) {
+        appState.add(1);
+        this.setState({appState});
+      } else {
+        appState.delete(1);
+        this.setState({appState});
+      }
+      console.log(this.state.appState)
+    } catch (e) {
+      console.error(e);
+    }
+  }
 
   toggleModal = () => {
     this.setState({ isModalVisible: !this.state.isModalVisible });
@@ -174,6 +209,7 @@ export default class Home extends Component {
 
   render() {
     const { messages, isModalVisible } = this.state;
+    
     return (
       <View style={{ flex: 1, backgroundColor: "#fff" }}>
         <GiftedChat

--- a/screens/data/messages.js
+++ b/screens/data/messages.js
@@ -1,5 +1,5 @@
 
-var sleep_diary_messages = [
+const sleep_diary_messages = [
   {
     _id: 1,
     text:
@@ -34,4 +34,26 @@ var sleep_diary_messages = [
   }
 ]
 
-export default sleep_diary_messages;
+const generic_messages = [
+  {
+    _id: 1,
+    text:
+      "This is a generic message",
+    createdAt: new Date(),
+    quickReplies: {
+      type: "radio", // or 'checkbox',
+      keepIt: true,
+      values: [
+        {
+          title: "Hi",
+          value: "hi"
+        }
+      ]
+    },
+    user: {
+      _id: 2,
+      name: "React Native"
+    }
+  }
+]
+export { generic_messages, sleep_diary_messages } ;

--- a/screens/loading.js
+++ b/screens/loading.js
@@ -1,0 +1,17 @@
+import React, { Component } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+
+export default class SplashScreen extends Component {
+  render() {
+
+    return (
+      <View style={{ flex: 1, backgroundColor: "#fff" }}>
+        <Text style={{ textAlign: "center", fontSize: 25}}>
+          Loading Sleep Well...
+        </Text>
+      </View>
+    );
+  }
+}
+

--- a/screens/utils/save-utils.js
+++ b/screens/utils/save-utils.js
@@ -4,7 +4,6 @@ import Map from 'lodash';
 
 const formatDate = (element) => element instanceof Date ? element.getTime() : element;
 
-
 export const storeSleepDiaryData = async res => {
   const formattedObj = Map(res, formatDate);
     

--- a/screens/welcome.js
+++ b/screens/welcome.js
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 
 export default class Welcome extends React.Component{
+
   render() {
     const { navigation } = this.props;
     return (


### PR DESCRIPTION
#### Link to the issue: 
https://github.com/de-souza-capstone-2020/Mars/issues/71

#### Description of Pull Request:
Looked into states. Using load screen to wait until async storage is able to determine if the user inputted a sleep diary or not, then shows the option to input sleep diary if they have not entered one for today. 

#### Test Plan:

- [ ] App loads fine
- [ ] "Go directly to chatbot"
- [ ] There should be a loading screen
- [ ] After a second the loading screen should direct to normal chatbot screen

