### PR TITLE
More Sleep Diary tips: sleep efficiency & naps

### DIFF
--- a/screens/SleepDiaryEdit.js
+++ b/screens/SleepDiaryEdit.js
@@ -100,7 +100,7 @@ export default class SleepDiaryEdit extends Component {
 
           <ScrollView style={styles.body}>
             <View style={styles.row}>
-              <Text style={styles.date}>{dateTime}</Text>
+              <Text style={styles.date}>Sleep Diary: {dateTime}</Text>
             </View>
             <View style={styles.row}>
               <View style={styles.question}>

--- a/screens/chat-screen/home.js
+++ b/screens/chat-screen/home.js
@@ -19,7 +19,8 @@ import {
   module,
   sleep_diary_reminder_messages,
   sleep_diary_tip_2,
-  sleep_diary_tip_1
+  sleep_diary_tip_1,
+  sleep_diary_tip_eff
 } from "../data/messages";
 import { getRandomAppState } from "../utils/helper-utils";
 import LottieLoader from "../loading";
@@ -70,7 +71,7 @@ export default class Home extends Component {
 };
   async componentDidMount() {
 
-   // AsyncStorage.removeItem(date);
+    AsyncStorage.removeItem(date);
     await this.isSleepDiaryEntered();
 
     //determining message type

--- a/screens/chat-screen/home.js
+++ b/screens/chat-screen/home.js
@@ -296,13 +296,13 @@ export default class Home extends Component {
 
     console.log("appState is:", appState);
     console.log("RandAppState is:", randAppState);
-    console.log("Sleep Time: ",sleepTime);
+    /* console.log("Sleep Time: ",sleepTime);
     console.log("Wake Time: ",wUT);
     console.log("Get in bed time: ",this.state.getInBedTime);
     console.log("Get out of bed time: ",this.state.leaveBedTime);
     console.log("Sleep Duration: ", sleepDurationMins);
     console.log("Total Time in Bed: ", totalTimeInBed);
-    console.log("Total Time in Bed Mins: ", totalTimeInBedMins);
+    console.log("Total Time in Bed Mins: ", totalTimeInBedMins); */
 
 
     if (this.state.appState.has(3)) {

--- a/screens/data/customActions.js
+++ b/screens/data/customActions.js
@@ -194,7 +194,82 @@ export const sleep_diary_response = reply => {
       }
     ]);
   }
+}; 
+
+export const sleep_diary_tip_nap = reply => {
+  if(reply.value === "nap_flow"){
+  return ([
+    {
+      createdAt: new Date(),
+      _id: getID(),
+      text: "Hey, you seem to be struggling with avoiding naps. Remember that napping disrupts the sleep rhythm you are trying to develop with the procedure and destroys any of its benefits.",
+      otherUser,
+      quickReplies: {
+        type: "radio", // or 'checkbox',
+        keepIt: true,
+        values: [
+          {
+            title: "I'll work on napping less",
+            value: "good_nap"
+          },
+          {
+            title: "It's hard not to nap",
+            value: "help_nap" 
+          } 
+        ]
+      },
+    }
+  ]);
+}
+
+  if(reply.value === "help_nap"){
+  return ([
+    {
+      createdAt: new Date(),
+      _id: getID(),
+      text: "Okay, so, one way to avoid napping is to engage in another activity incompatible with napping when the get to urge to sleep during the day",
+      otherUser,
+      quickReplies: {
+        type: "radio", // or 'checkbox',
+        keepIt: true,
+        values: [
+          {
+            title: "👍",
+            value: "got_it"
+          },
+          {
+            title: "It'll be hard but i'll try",
+            value: "got_it" 
+          }
+        ]
+      },
+    }
+  ]);
+}
+
+if(reply.value === "good_nap"){
+  return ([
+    {
+      createdAt: new Date(),
+      _id: getID(),
+      text: "Some ways to nap less include engaging in other activities that are incompatible with napping when you feel the urge to nap.",
+      otherUser,
+      quickReplies: {
+        type: "radio", // or 'checkbox',
+        keepIt: true,
+        values: [
+          {
+            title: "👍",
+            value: "got_it"
+          }
+        ]
+      },
+    }
+  ]);
+}
+
 };
+
 
 export const conversation_flow_one = reply => {
     
@@ -204,7 +279,7 @@ export const conversation_flow_one = reply => {
             {
               createdAt,
               _id: getID(),
-              text: "Hello. Having trouble sleeping? Did you know that the best way to fix this is to actually limit how much time you’re spending in bed? ",
+              text: "Did you know that the best way to fix your trouble sleeping is to actually limit how much time you’re spending in bed? ",
               otherUser,
               quickReplies: {
                 type: "radio", // or 'checkbox',
@@ -346,7 +421,7 @@ export const conversation_flow_one = reply => {
             {
               createdAt,
               _id: getID(),
-              text: "Alright. First you need to pick a a consistent tim every morning to wake up during the week. Based on your current sleep ability use this amount of time and add 30 minutes. Count backwards to figure out your new bedtime. As you work on sleep restriction you wil gradually increase your sleep quantity. Is this something you think you are able to do?",
+              text: "Alright. First you need to pick a a consistent time every morning to wake up during the week. Based on your current sleep ability use this amount of time and add 30 minutes. Count backwards to figure out your new bedtime. As you work on sleep restriction you wil gradually increase your sleep quantity. Is this something you think you are able to do?",
               otherUser,
               quickReplies: {
                 type: "radio", // or 'checkbox',

--- a/screens/data/messages.js
+++ b/screens/data/messages.js
@@ -130,7 +130,7 @@ const sleep_diary_tip_1 = () => {
     {
       createdAt: new Date(),
       _id: getID(),
-      text: "Sleep diary tip: Hey , lying in bed while awake reinforces the role of your bed as a stimulus for wakefulness.Spending less time in bed strengthens the role of your bed as the place to sleep.",
+      text: "Sleep diary tip: Hey, lying in bed while awake reinforces the role of your bed as a stimulus for wakefulness.Spending less time in bed strengthens the role of your bed as the place to sleep.",
       otherUser,
       quickReplies: {
         type: "radio", // or 'checkbox',
@@ -167,6 +167,27 @@ const sleep_diary_tip_2 = () => {
   ]
 }
 
+const sleep_diary_tip_eff = (sleepEff) => {
+  return [
+    {
+      createdAt: new Date(),
+      _id: getID(),
+      text: "Sleep diary tip: You know now why spending excessive time in bed not sleeping is bad for your sleep pattern. Keep finding ways to reduce your time in bed!!" + sleepEff,
+      otherUser,
+      quickReplies: {
+        type: "radio", // or 'checkbox',
+        keepIt: true,
+        values: [
+          {
+            title: "got it",
+            value: "got_it"
+          }
+        ]
+      },
+    }
+  ]
+}
+
 const module = () => {
   return [
     {
@@ -187,4 +208,4 @@ const module = () => {
     }
   ]
 }
-export { generic_messages, sleep_diary_messages, generic_tip, sleep_diary_tip, module, sleep_diary_reminder_messages,sleep_diary_tip_2,sleep_diary_tip_1};
+export { generic_messages, sleep_diary_messages, generic_tip, sleep_diary_tip, module, sleep_diary_reminder_messages,sleep_diary_tip_2,sleep_diary_tip_1,sleep_diary_tip_eff};

--- a/screens/data/messages.js
+++ b/screens/data/messages.js
@@ -61,7 +61,7 @@ const sleep_diary_reminder_messages = () => {
     {
       _id: getID(),
       text:
-        "It is important to enter your sleep diary information everyday.This will allow us provide customized tips.",
+        "It is important to enter your complete sleep diary information everyday.This will allow us provide customized tips.",
       createdAt: new Date(),
       quickReplies: {
         type: "radio", // or 'checkbox',
@@ -130,7 +130,7 @@ const sleep_diary_tip_1 = () => {
     {
       createdAt: new Date(),
       _id: getID(),
-      text: "Sleep diary tip: Hey, lying in bed while awake reinforces the role of your bed as a stimulus for wakefulness.Spending less time in bed strengthens the role of your bed as the place to sleep.",
+      text: "Sleep diary tip: Hey, lying in bed while awake reinforces the role of your bed as a stimulus for wakefulness.Spending less time in bed strengthens the role of your bed as the place to sleep." ,
       otherUser,
       quickReplies: {
         type: "radio", // or 'checkbox',
@@ -172,7 +172,7 @@ const sleep_diary_tip_eff = (sleepEff) => {
     {
       createdAt: new Date(),
       _id: getID(),
-      text: "Sleep diary tip: You know now why spending excessive time in bed not sleeping is bad for your sleep pattern. Keep finding ways to reduce your time in bed!!" + sleepEff,
+      text: "Your sleep efficency today is: " + sleepEff + "%",
       otherUser,
       quickReplies: {
         type: "radio", // or 'checkbox',

--- a/screens/data/messages.js
+++ b/screens/data/messages.js
@@ -130,7 +130,7 @@ const sleep_diary_tip_1 = () => {
     {
       createdAt: new Date(),
       _id: getID(),
-      text: "Sleep diary tip: Hey, lying in bed while awake reinforces the role of your bed as a stimulus for wakefulness.Spending less time in bed strengthens the role of your bed as the place to sleep." ,
+      text: "Sleep diary tip: Lying in bed while awake reinforces the role of your bed as a stimulus for wakefulness.Spending less time in bed strengthens the role of your bed as the place to sleep." ,
       otherUser,
       quickReplies: {
         type: "radio", // or 'checkbox',
@@ -151,7 +151,7 @@ const sleep_diary_tip_2 = () => {
     {
       createdAt: new Date(),
       _id: getID(),
-      text: "Sleep diary tip: You know now why spending excessive time in bed not sleeping is bad for your sleep pattern. Keep finding ways to reduce your time in bed!!",
+      text: "Sleep diary tip: Great job! You know now why spending excessive time in bed not sleeping is bad for your sleep pattern. Keep finding ways to reduce your time in bed!!",
       otherUser,
       quickReplies: {
         type: "radio", // or 'checkbox',
@@ -179,7 +179,7 @@ const sleep_diary_tip_eff = (sleepEff) => {
         keepIt: true,
         values: [
           {
-            title: "got it",
+            title: "I see",
             value: "got_it"
           }
         ]
@@ -187,6 +187,8 @@ const sleep_diary_tip_eff = (sleepEff) => {
     }
   ]
 }
+
+
 
 const module = () => {
   return [

--- a/screens/sleepDiary.js
+++ b/screens/sleepDiary.js
@@ -16,16 +16,16 @@ import { storeSleepDiaryData } from './utils/save-utils';
 export default class SleepDiary extends Component {
   state = {
     sleepQuality: "",
-    sleepTime: new Date(),
-    attemptToSleepTime: new Date(),
-    durationTillSleep: "",
-    numTimesWakeUp: "",
-    durationTotalWakeUp: "",
+    sleepTime: yesterday,
+    attemptToSleepTime: yesterday,
+    getInBedTime: yesterday,
+    numTimesWakeUp: 0,
+    durationTotalWakeUp: 0,
     wakeUpTime: new Date(),
     leaveBedTime: new Date(),
     didNap: "",
     napTime: new Date(),
-    napDuration: "",
+    napDuration: 0,
     others: ""
   };
 
@@ -36,7 +36,7 @@ export default class SleepDiary extends Component {
         sleepQuality,
         sleepTime,
         attemptToSleepTime,
-        durationTillSleep,
+        getInBedTime,
         numTimesWakeUp,
         durationTotalWakeUp,
         wakeUpTime,
@@ -51,7 +51,7 @@ export default class SleepDiary extends Component {
         sleepQuality,
         sleepTime,
         attemptToSleepTime,
-        durationTillSleep,
+        getInBedTime,
         numTimesWakeUp,
         durationTotalWakeUp,
         wakeUpTime,
@@ -73,7 +73,7 @@ export default class SleepDiary extends Component {
       sleepQuality,
       sleepTime,
       attemptToSleepTime,
-      durationTillSleep,
+      getInBedTime,
       numTimesWakeUp,
       durationTotalWakeUp,
       wakeUpTime,
@@ -101,8 +101,8 @@ export default class SleepDiary extends Component {
               </View>
               <View style={styles.answer}>
                 <DatePicker
-                  date={sleepTime}
-                  onDateChange={sleepTime => this.setState({ sleepTime })}
+                  date={getInBedTime}
+                  onDateChange={getInBedTime => this.setState({ getInBedTime })}
                   mode={"time"}
                   fadeToColor={"none"}
                   textColor={"#000000"}
@@ -132,25 +132,24 @@ export default class SleepDiary extends Component {
             <View style={styles.row}>
               <View style={styles.question}>
                 <Text style={styles.text}>
-                  How long did it take you to fall asleep (min)?
+                  What time did you fall asleep?
                 </Text>
               </View>
               <View style={styles.answer}>
-                <TextInput
-                  placeholder={"0.5"}
-                  style={styles.textBox}
-                  keyboardType="numeric"
-                  value={durationTillSleep}
-                  onChangeText={durationTillSleep =>
-                    this.setState({ durationTillSleep })
-                  }
+                <DatePicker
+                  date={sleepTime}
+                  onDateChange={sleepTime => this.setState({ sleepTime })}
+                  mode={"time"}
+                  fadeToColor={"none"}
+                  textColor={"#000000"}
+                  style={{ height: 50, width: 120 }}
                 />
               </View>
             </View>
             <View style={styles.row}>
               <View style={styles.question}>
                 <Text style={styles.text}>
-                  How many times did you wake up, not counting your final
+                  How many times did you wake up during the night, not counting your final
                   awakening?
                 </Text>
               </View>
@@ -324,6 +323,12 @@ export default class SleepDiary extends Component {
     );
   }
 }
+
+
+  const yesterday = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
+
+
+
 
 const styles = StyleSheet.create({
   body: {

--- a/screens/sleepDiary.js
+++ b/screens/sleepDiary.js
@@ -68,7 +68,7 @@ export default class SleepDiary extends Component {
 
   render() {
     const today = new Date();
-    const todayFormatted = `${parseInt(today.getMonth() + 1)}, ${today.getDate()}, ${today.getFullYear()}`;
+    const todayFormatted = `${parseInt(today.getMonth() + 1)}-${today.getDate()}-${today.getFullYear()}`;
     const {
       sleepQuality,
       sleepTime,
@@ -93,7 +93,7 @@ export default class SleepDiary extends Component {
 
           <ScrollView style={styles.body}>
             <View style={styles.row}>
-              <Text style={styles.date}>{todayFormatted}</Text>
+              <Text style={styles.date}>Sleep Diary: {todayFormatted}</Text>
             </View>
             <View style={styles.row}>
               <View style={styles.question}>

--- a/screens/sleepDiary.js
+++ b/screens/sleepDiary.js
@@ -186,7 +186,7 @@ export default class SleepDiary extends Component {
             <View style={styles.row}>
               <View style={styles.question}>
                 <Text style={styles.text}>
-                  What time was your final awakening?
+                  What time was your final awakening today?
                 </Text>
               </View>
               <View style={styles.answer}>
@@ -203,7 +203,7 @@ export default class SleepDiary extends Component {
             <View style={styles.row}>
               <View style={styles.question}>
                 <Text style={styles.text}>
-                  What time did you get out of bed that day?
+                  What time did you get out of bed today?
                 </Text>
               </View>
               <View style={styles.answer}>


### PR DESCRIPTION
#### Link to the issue: 
https://github.com/de-souza-capstone-2020/Mars/issues/104
#### Description of Pull Request:
- Sleep diary form and heading slightly modified to accomodate sleep efficiency calculation
 - Assuming user enters sleep diary info in the morning or during the day: Dates for wake up time and get out of bed time are initialized as today's date and the other dates are for the day before (this is important when calculating the time difference between dates)
- Sleep Efficiency is calculated and given to user as chatbot message= (sleep duration ÷ total time in bed) x 100% (https://mysleepwell.ca/cbti/sleep-diary/)
- If user entered 'yes' to nap in sleep diary, nap tips are given 

#### Test Plan:
- [ ] Test sleep efficiency calculation by not making any changes to the sleep diary form and submitting it(i.e. it's default values), you should get a sleep efficiency of 100%
- [ ] Fill out sleep diary form information with dates that make sense(i.e the time you attempt to sleep should be a value earlier than the time you slept etc), enter no for nap
- [ ] Iterate through messages until you get a sleep efficiency message, you should get no nap tips 
- [ ] Repeat 1, but enter yes to nap, you should get nap tips


